### PR TITLE
ci: auto-merge patch/minor Dependabot PRs; track GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,14 @@ updates:
       include: "scope"
   reviewers:
   - raimondb
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly
+    time: "04:00"
+  open-pull-requests-limit: 10
+  commit-message:
+      prefix: "ci"
+      include: "scope"
+  reviewers:
+  - raimondb

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,30 @@
+# Auto-merges Dependabot PRs for patch and minor updates once the
+# branch-protection required checks pass. Major version bumps are left
+# for manual review (a major can be a breaking/ESM-only change).
+
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Enable auto-merge for patch and minor updates
+        if: >-
+          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+          steps.meta.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What
- **Dependabot auto-merge workflow** — enables GitHub auto-merge (squash) on Dependabot PRs for **patch & minor** updates. Branch protection still gates the real merge on CI passing.
- **Major updates stay manual** — exactly the `color-convert@3` ESM situation we just hit; majors need a human.
- **github-actions ecosystem added to dependabot** — actions self-maintain weekly with a `ci:` prefix (no semantic-release release).

## Semantic-release commit hygiene
| Update | Prefix | Effect |
|---|---|---|
| npm prod dep | `fix(deps):` | patch release |
| npm dev dep | `build(deps-dev):` | no release |
| GitHub Actions | `ci(...):` | no release |

## Note
"Allow auto-merge" repo setting already enabled. Best merged after #406 so the inlined CI checks are the ones gating auto-merge.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)