### PR TITLE
ci: ignore unfixable transitive deps in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,14 @@ updates:
       include: "scope"
   reviewers:
   - raimondb
+  # Transitive deps bundled deep in dev tooling (mocha/node-red/
+  # semantic-release) that Dependabot cannot patch here, so its
+  # security-update jobs fail every run with update_not_possible.
+  # Ignore to stop the noise; npm audit still reports them.
+  ignore:
+  - dependency-name: "serialize-javascript"
+  - dependency-name: "picomatch"
+  - dependency-name: "ip-address"
 - package-ecosystem: github-actions
   directory: "/"
   schedule:


### PR DESCRIPTION
Follow-up to #406. The old `tar` security-update failure was resolved by the regenerated lockfile, but the new dependency graph surfaced a fresh set of impossible security updates:

| Dep | Why unfixable |
|---|---|
| serialize-javascript | bundled via mocha |
| picomatch | bundled via node-red |
| ip-address | bundled via semantic-release (socks-proxy-agent) |

All report `update_not_possible`, so the [Dependabot Updates](https://github.com/RaimondB/node-red-contrib-daylight-rgbw/actions/workflows/dependabot/dependabot-updates) workflow shows red every run. Added an `ignore` list scoped to exactly these three. Regular version-update PRs are unaffected; `npm audit` still reports them. Same pattern as nefit-easy #415.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)