### PR TITLE
chore: declare node-red.version for scorecard

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "rgbw"
   ],
   "node-red": {
+    "version": ">=3.0.0",
     "nodes": {
       "daylight-rgbw": "daylight-rgbw.js",
       "animate-rgbw": "animate-rgbw.js"


### PR DESCRIPTION
Fixes the only [scorecard](https://flows.nodered.org/node/node-red-contrib-daylight-rgbw/scorecard) warning:

> ⚠️ Supported Node-RED Version — **Missing**: no specific Node-RED version compatibility declared

The `node-red` section in package.json had `nodes` but no `version`. Added **`"version": ">=3.0.0"`** — accurate given `engines.node: ">=18.5"` (node-red 4.1.10 requires Node ≥18.5; node-red 3.1 runs on ≥14). `engines.node` is already current at `>=18.5`, so no other metadata change is needed here.

Verified on Node 24.15.0: `npm ci` clean, 7/7 tests pass. No lockfile change (the `node-red` field is not npm-tracked metadata).

🤖 Generated with [Claude Code](https://claude.com/claude-code)